### PR TITLE
Let Sinatra::URL::Route instances delegate to the pattern

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require "rake/testtask"
 begin
   require "hanna/rdoctask"
 rescue LoadError
-  require "rake/rdoctask"
+  require 'rdoc/task'
 end
 
 Rake::RDocTask.new do |rd|

--- a/lib/sinatra/url.rb
+++ b/lib/sinatra/url.rb
@@ -95,6 +95,12 @@ module Sinatra
           raise TypeError, path
         end
       end
+
+      # Some middleware expects this to behave like a pattern
+      def method_missing(name, *args, &block)
+        @pattern.send(name, *args, &block)
+      end
+
     end
 
     module DSL

--- a/sinatra-urls.gemspec
+++ b/sinatra-urls.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "sinatra-url"
-  s.version     = "0.0.1"
+  s.version     = "0.0.2"
   s.description = "Simple sinatra extension that gives you the ability to use named URLs in your code"
   s.summary     = "Named URLs for Sinatra apps"
   s.authors     = ["Nicolas Sanguinetti"]


### PR DESCRIPTION
There is Rack middleware which requires the routes to behave like normal regex instances. For example newrelic_rpm requires the routes to respond to the source method. This pull request changes Sinatra::URL::Route to delegate any unknown methods to the @pattern variable it holds.
